### PR TITLE
refactor: make daemon session aware

### DIFF
--- a/apps/tui/src/components/app.tsx
+++ b/apps/tui/src/components/app.tsx
@@ -3,6 +3,7 @@ import { type SelectOption, TextAttributes } from "@opentui/core";
 import { useKeyboard } from "@opentui/react";
 import type {
 	DaemonJob,
+	DaemonSession,
 	HealthResult,
 	ManagedInstance,
 } from "@techatnyu/ralphd";
@@ -13,7 +14,12 @@ import { Chat } from "./chat";
 
 type View =
 	| { type: "dashboard" }
-	| { type: "chat"; instanceId: string; instanceName: string };
+	| {
+			type: "chat";
+			instanceId: string;
+			instanceName: string;
+			sessionId: string | null;
+	  };
 
 interface DashboardData {
 	health: HealthResult;
@@ -108,12 +114,20 @@ function Dashboard({
 	onSelectInstance,
 }: {
 	onQuit(): void;
-	onSelectInstance(instance: ManagedInstance): void;
+	onSelectInstance(
+		instance: ManagedInstance,
+		session: DaemonSession | null,
+	): void;
 }) {
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string>();
 	const [data, setData] = useState<DashboardData>();
 	const [selectedIndex, setSelectedIndex] = useState(0);
+	const [sessions, setSessions] = useState<DaemonSession[]>([]);
+	const [selectedSessionIndex, setSelectedSessionIndex] = useState(0);
+	const [focusPanel, setFocusPanel] = useState<"instances" | "sessions">(
+		"instances",
+	);
 	const [currentModel, setCurrentModel] = useState("");
 	const [modelPicker, setModelPicker] = useState(false);
 	const [modelOptions, setModelOptions] = useState<SelectOption[]>([]);
@@ -150,11 +164,16 @@ function Dashboard({
 				]);
 				setCurrentModel(storeState.model);
 				const safeIndex = clampIndex(nextIndex, instanceList.instances.length);
-				const selected = instanceList.instances[safeIndex];
-				const jobs = await daemon.listJobs(
-					selected ? { instanceId: selected.id } : {},
-				);
+				const selectedInst = instanceList.instances[safeIndex];
+				const [jobs, sessionResult] = await Promise.all([
+					daemon.listJobs(selectedInst ? { instanceId: selectedInst.id } : {}),
+					selectedInst
+						? daemon.listSessions(selectedInst.id)
+						: Promise.resolve({ sessions: [] }),
+				]);
 				setSelectedIndex(safeIndex);
+				setSessions(sessionResult.sessions);
+				setSelectedSessionIndex(0);
 				setData({
 					health,
 					instances: instanceList.instances,
@@ -232,24 +251,77 @@ function Dashboard({
 			return;
 		}
 
-		if (key.name === "down" || key.name === "j") {
-			const next = clampIndex(selectedIndex + 1, data.instances.length);
-			void refresh(next);
-			return;
-		}
-
-		if (key.name === "up" || key.name === "k") {
-			const next = clampIndex(selectedIndex - 1, data.instances.length);
-			void refresh(next);
-			return;
-		}
-
-		if (key.name === "return") {
-			const selected = data.instances[selectedIndex];
-			if (selected) {
-				onSelectInstance(selected);
+		if (key.name === "tab" || key.name === "l" || key.name === "right") {
+			if (focusPanel === "instances" && sessions.length > 0) {
+				setFocusPanel("sessions");
 			}
 			return;
+		}
+
+		if (key.name === "h" || key.name === "left") {
+			if (focusPanel === "sessions") {
+				setFocusPanel("instances");
+			}
+			return;
+		}
+
+		if (focusPanel === "instances") {
+			if (key.name === "down" || key.name === "j") {
+				const next = clampIndex(selectedIndex + 1, data.instances.length);
+				void refresh(next);
+				return;
+			}
+
+			if (key.name === "up" || key.name === "k") {
+				const next = clampIndex(selectedIndex - 1, data.instances.length);
+				void refresh(next);
+				return;
+			}
+
+			if (key.name === "return") {
+				const inst = data.instances[selectedIndex];
+				if (inst) {
+					onSelectInstance(inst, null);
+				}
+				return;
+			}
+		}
+
+		if (focusPanel === "sessions") {
+			if (key.name === "down" || key.name === "j") {
+				setSelectedSessionIndex((prev) =>
+					clampIndex(prev + 1, sessions.length + 1),
+				);
+				return;
+			}
+
+			if (key.name === "up" || key.name === "k") {
+				setSelectedSessionIndex((prev) =>
+					clampIndex(prev - 1, sessions.length + 1),
+				);
+				return;
+			}
+
+			if (key.name === "return") {
+				const inst = data.instances[selectedIndex];
+				if (!inst) return;
+
+				// Index 0 is "New Chat", rest are sessions
+				if (selectedSessionIndex === 0) {
+					onSelectInstance(inst, null);
+				} else {
+					const session = sessions[selectedSessionIndex - 1];
+					if (session) {
+						onSelectInstance(inst, session);
+					}
+				}
+				return;
+			}
+
+			if (key.name === "escape") {
+				setFocusPanel("instances");
+				return;
+			}
 		}
 	});
 
@@ -348,23 +420,44 @@ function Dashboard({
 
 				<box flexDirection="column" width="45%">
 					<text attributes={TextAttributes.BOLD}>
-						{selected ? `Jobs for ${selected.name}` : "Jobs"}
+						{selected ? `Sessions for ${selected.name}` : "Sessions"}
 					</text>
 					{selected ? (
-						data?.jobs.length ? (
-							data.jobs.map((job: DaemonJob) => (
-								<text key={job.id} attributes={TextAttributes.DIM}>
-									{`${job.id.slice(0, 8)} ${job.state} ${job.task.type === "prompt" ? job.task.prompt : ""}`}
-								</text>
-							))
-						) : (
-							<text attributes={TextAttributes.DIM}>
-								No jobs for the selected instance
+						<>
+							<text
+								attributes={
+									focusPanel === "sessions" && selectedSessionIndex === 0
+										? TextAttributes.BOLD
+										: TextAttributes.DIM
+								}
+							>
+								{`${focusPanel === "sessions" && selectedSessionIndex === 0 ? ">" : " "} + New Chat`}
 							</text>
-						)
+							{sessions.length > 0 ? (
+								sessions.map((session: DaemonSession, index: number) => {
+									const focused =
+										focusPanel === "sessions" &&
+										index === selectedSessionIndex - 1;
+									return (
+										<text
+											key={session.id}
+											attributes={
+												focused ? TextAttributes.BOLD : TextAttributes.DIM
+											}
+										>
+											{`${focused ? ">" : " "} ${session.title}`}
+										</text>
+									);
+								})
+							) : (
+								<text attributes={TextAttributes.DIM}>
+									No sessions yet — press enter to start
+								</text>
+							)}
+						</>
 					) : (
 						<text attributes={TextAttributes.DIM}>
-							Select an instance to inspect jobs
+							Select an instance to see sessions
 						</text>
 					)}
 				</box>
@@ -373,7 +466,7 @@ function Dashboard({
 			<box flexDirection="column" marginTop={1}>
 				<text attributes={TextAttributes.DIM}>
 					{error ??
-						"j/k or arrows: select  enter: chat  m: model  r: refresh  q: quit"}
+						"j/k: select  tab/h/l: switch panel  enter: open  m: model  r: refresh  q: quit"}
 				</text>
 			</box>
 		</box>
@@ -388,6 +481,7 @@ export function App({ onQuit }: AppProps) {
 			<Chat
 				instanceId={view.instanceId}
 				instanceName={view.instanceName}
+				sessionId={view.sessionId}
 				onBack={() => setView({ type: "dashboard" })}
 				onQuit={onQuit}
 			/>
@@ -397,11 +491,12 @@ export function App({ onQuit }: AppProps) {
 	return (
 		<Dashboard
 			onQuit={onQuit}
-			onSelectInstance={(instance) =>
+			onSelectInstance={(instance, session) =>
 				setView({
 					type: "chat",
 					instanceId: instance.id,
 					instanceName: instance.name,
+					sessionId: session?.id ?? null,
 				})
 			}
 		/>

--- a/apps/tui/src/components/chat.tsx
+++ b/apps/tui/src/components/chat.tsx
@@ -44,16 +44,23 @@ function messagesFromJob(job: DaemonJob): ChatMessage[] {
 interface ChatProps {
 	instanceId: string;
 	instanceName: string;
+	sessionId: string | null;
 	onBack(): void;
 	onQuit(): void;
 }
 
-export function Chat({ instanceId, instanceName, onBack, onQuit }: ChatProps) {
+export function Chat({
+	instanceId,
+	instanceName,
+	sessionId: initialSessionId,
+	onBack,
+	onQuit,
+}: ChatProps) {
 	const [messages, setMessages] = useState<ChatMessage[]>([]);
 	const [inputValue, setInputValue] = useState("");
 	const [isLoading, setIsLoading] = useState(false);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
-	const [sessionId, setSessionId] = useState<string | null>(null);
+	const [sessionId, setSessionId] = useState<string | null>(initialSessionId);
 	const [hydrated, setHydrated] = useState(false);
 	const sendLockRef = useRef(false);
 	const chatScrollRef = useRef<ScrollBoxRenderable | null>(null);
@@ -142,7 +149,19 @@ export function Chat({ instanceId, instanceName, onBack, onQuit }: ChatProps) {
 
 		(async () => {
 			try {
-				const result = await daemon.listJobs({ instanceId });
+				// New chat — no session yet, nothing to hydrate.
+				if (!sessionId) {
+					setMessages([
+						msg(
+							"assistant",
+							`Connected to instance "${instanceName}". Send a message to start.`,
+						),
+					]);
+					setHydrated(true);
+					return;
+				}
+
+				const result = await daemon.listJobs({ instanceId, sessionId });
 				if (cancelled) return;
 
 				const sorted = result.jobs.sort(
@@ -150,22 +169,7 @@ export function Chat({ instanceId, instanceName, onBack, onQuit }: ChatProps) {
 						new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
 				);
 
-				// Find the most recent sessionId to scope the conversation.
-				let latestSessionId: string | null = null;
-				for (let i = sorted.length - 1; i >= 0; i--) {
-					const job = sorted[i];
-					if (job?.sessionId) {
-						latestSessionId = job.sessionId;
-						break;
-					}
-				}
-
-				// Filter to jobs in this session (or all if no session found).
-				const sessionJobs = latestSessionId
-					? sorted.filter((j) => j.sessionId === latestSessionId)
-					: sorted;
-
-				if (sessionJobs.length === 0) {
+				if (sorted.length === 0) {
 					setMessages([
 						msg(
 							"assistant",
@@ -180,7 +184,7 @@ export function Chat({ instanceId, instanceName, onBack, onQuit }: ChatProps) {
 				const history: ChatMessage[] = [];
 				let runningJob: DaemonJob | null = null;
 
-				for (const job of sessionJobs) {
+				for (const job of sorted) {
 					if (
 						job.state === "succeeded" ||
 						job.state === "failed" ||
@@ -192,7 +196,6 @@ export function Chat({ instanceId, instanceName, onBack, onQuit }: ChatProps) {
 					}
 				}
 
-				setSessionId(latestSessionId);
 				setMessages(history);
 				setHydrated(true);
 
@@ -229,7 +232,7 @@ export function Chat({ instanceId, instanceName, onBack, onQuit }: ChatProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [instanceId, instanceName, consumeStream]);
+	}, [instanceId, instanceName, sessionId, consumeStream]);
 
 	useKeyboard((event) => {
 		if (event.ctrl && event.name === "c") {

--- a/packages/daemon/src/__tests__/daemon.test.ts
+++ b/packages/daemon/src/__tests__/daemon.test.ts
@@ -278,6 +278,7 @@ describe("Daemon", () => {
 					updatedAt: "2026-01-01T00:00:00.000Z",
 				},
 			],
+			sessions: [],
 			jobs: [
 				{
 					id: "job-1",
@@ -306,6 +307,250 @@ describe("Daemon", () => {
 			expectSuccess(response, "job.get").job.state,
 		);
 		await nextDaemon.shutdown();
+	});
+});
+
+describe("Daemon sessions", () => {
+	let tmpDir: string;
+	let store: StateStore;
+	let registry: FakeOpencodeRegistry;
+	let daemon: Daemon;
+
+	beforeEach(async () => {
+		tmpDir = await mkdtemp(join(tmpdir(), "ralph-daemon-session-"));
+		store = new StateStore(join(tmpDir, "state.json"));
+		registry = new FakeOpencodeRegistry(10);
+		daemon = new Daemon(store, { registry });
+		await daemon.bootstrap();
+	});
+
+	afterEach(async () => {
+		await daemon.shutdown();
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	async function createInstance(
+		name = "One",
+		directory = "/tmp/project-one",
+	): Promise<string> {
+		const res = await daemon.handleRequest(
+			req({
+				id: `create-${name}`,
+				method: "instance.create",
+				params: { name, directory },
+			}),
+		);
+		return expectSuccess(res, "instance.create").instance.id;
+	}
+
+	test("creates a session when a new-session job completes", async () => {
+		const instanceId = await createInstance();
+
+		await daemon.handleRequest(
+			req({
+				id: "submit",
+				method: "job.submit",
+				params: {
+					instanceId,
+					session: { type: "new" },
+					task: { type: "prompt", prompt: "hello world" },
+				},
+			}),
+		);
+
+		await Bun.sleep(80);
+
+		const res = await daemon.handleRequest(
+			req({
+				id: "session-list",
+				method: "session.list",
+				params: { instanceId },
+			}),
+		);
+		const result = expectSuccess(res, "session.list");
+		expect(result.sessions).toHaveLength(1);
+		expect(result.sessions[0]?.instanceId).toBe(instanceId);
+		expect(result.sessions[0]?.title).toBe("hello world");
+	});
+
+	test("derives title from prompt text, truncating long prompts", async () => {
+		const instanceId = await createInstance();
+		const longPrompt = "a".repeat(200);
+
+		await daemon.handleRequest(
+			req({
+				id: "submit",
+				method: "job.submit",
+				params: {
+					instanceId,
+					session: { type: "new" },
+					task: { type: "prompt", prompt: longPrompt },
+				},
+			}),
+		);
+
+		await Bun.sleep(80);
+
+		const res = await daemon.handleRequest(
+			req({
+				id: "session-list",
+				method: "session.list",
+				params: { instanceId },
+			}),
+		);
+		const result = expectSuccess(res, "session.list");
+		expect(result.sessions[0]?.title.length).toBeLessThanOrEqual(80);
+		const title = result.sessions[0]?.title ?? "";
+		expect(title).toEndWith("...");
+	});
+
+	test("session.get returns a specific session", async () => {
+		const instanceId = await createInstance();
+
+		await daemon.handleRequest(
+			req({
+				id: "submit",
+				method: "job.submit",
+				params: {
+					instanceId,
+					session: { type: "new" },
+					task: { type: "prompt", prompt: "test get" },
+				},
+			}),
+		);
+
+		await Bun.sleep(80);
+
+		const listRes = await daemon.handleRequest(
+			req({
+				id: "session-list",
+				method: "session.list",
+				params: { instanceId },
+			}),
+		);
+		const sessions = expectSuccess(listRes, "session.list").sessions;
+		const session = sessions[0];
+		if (!session) throw new Error("expected at least one session");
+
+		const getRes = await daemon.handleRequest(
+			req({
+				id: "session-get",
+				method: "session.get",
+				params: { sessionId: session.id },
+			}),
+		);
+		const result = expectSuccess(getRes, "session.get");
+		expect(result.session.id).toBe(session.id);
+		expect(result.session.title).toBe("test get");
+	});
+
+	test("job.list filters by sessionId", async () => {
+		const instanceId = await createInstance();
+
+		// Submit two jobs that create separate sessions
+		await daemon.handleRequest(
+			req({
+				id: "submit-1",
+				method: "job.submit",
+				params: {
+					instanceId,
+					session: { type: "new" },
+					task: { type: "prompt", prompt: "first session" },
+				},
+			}),
+		);
+
+		await Bun.sleep(80);
+
+		await daemon.handleRequest(
+			req({
+				id: "submit-2",
+				method: "job.submit",
+				params: {
+					instanceId,
+					session: { type: "new" },
+					task: { type: "prompt", prompt: "second session" },
+				},
+			}),
+		);
+
+		await Bun.sleep(80);
+
+		// Get all jobs — should be 2
+		const allRes = await daemon.handleRequest(
+			req({
+				id: "job-list-all",
+				method: "job.list",
+				params: { instanceId },
+			}),
+		);
+		const allJobs = expectSuccess(allRes, "job.list").jobs;
+		expect(allJobs).toHaveLength(2);
+
+		// Get the sessionId of the first job
+		const firstJob = allJobs.find(
+			(j) => j.task.type === "prompt" && j.task.prompt === "first session",
+		);
+		if (!firstJob?.sessionId) throw new Error("expected job with sessionId");
+
+		// Filter by that sessionId
+		const filteredRes = await daemon.handleRequest(
+			req({
+				id: "job-list-filtered",
+				method: "job.list",
+				params: { instanceId, sessionId: firstJob.sessionId },
+			}),
+		);
+		const filtered = expectSuccess(filteredRes, "job.list").jobs;
+		expect(filtered).toHaveLength(1);
+		expect(filtered[0]?.sessionId).toBe(firstJob.sessionId);
+	});
+
+	test("removing an instance cascades to its sessions", async () => {
+		const instanceId = await createInstance();
+
+		await daemon.handleRequest(
+			req({
+				id: "submit",
+				method: "job.submit",
+				params: {
+					instanceId,
+					session: { type: "new" },
+					task: { type: "prompt", prompt: "doomed" },
+				},
+			}),
+		);
+
+		await Bun.sleep(80);
+
+		// Verify session exists
+		const before = await daemon.handleRequest(
+			req({
+				id: "session-list-before",
+				method: "session.list",
+				params: { instanceId },
+			}),
+		);
+		expect(expectSuccess(before, "session.list").sessions).toHaveLength(1);
+
+		// Remove the instance
+		await daemon.handleRequest(
+			req({
+				id: "instance-remove",
+				method: "instance.remove",
+				params: { instanceId },
+			}),
+		);
+
+		// Verify sessions are gone
+		const after = await daemon.handleRequest(
+			req({
+				id: "session-list-after",
+				method: "session.list",
+				params: { instanceId },
+			}),
+		);
+		expect(expectSuccess(after, "session.list").sessions).toHaveLength(0);
 	});
 });
 

--- a/packages/daemon/src/__tests__/protocol.test.ts
+++ b/packages/daemon/src/__tests__/protocol.test.ts
@@ -66,6 +66,7 @@ describe("protocol schemas", () => {
 	test("parses daemon state", () => {
 		const parsed = DaemonState.safeParse({
 			instances: [],
+			sessions: [],
 			jobs: [],
 		});
 

--- a/packages/daemon/src/__tests__/store.test.ts
+++ b/packages/daemon/src/__tests__/store.test.ts
@@ -51,12 +51,13 @@ describe("StateStore", () => {
 
 	test("returns empty state when file does not exist", async () => {
 		const state = await store.load();
-		expect(state).toEqual({ instances: [], jobs: [] });
+		expect(state).toEqual({ instances: [], sessions: [], jobs: [] });
 	});
 
 	test("writes state to disk as formatted JSON", async () => {
 		const state: DaemonState = {
 			instances: [makeInstance()],
+			sessions: [],
 			jobs: [makeJob()],
 		};
 		await store.save(state);
@@ -69,7 +70,7 @@ describe("StateStore", () => {
 	});
 
 	test("adds and updates instances", () => {
-		let state: DaemonState = { instances: [], jobs: [] };
+		let state: DaemonState = { instances: [], sessions: [], jobs: [] };
 		state = store.createInstance(state, makeInstance());
 		expect(state.instances).toHaveLength(1);
 		state = store.upsertInstance(
@@ -85,6 +86,7 @@ describe("StateStore", () => {
 	test("rejects duplicate instance directories", () => {
 		const state: DaemonState = {
 			instances: [makeInstance()],
+			sessions: [],
 			jobs: [],
 		};
 		expect(() =>
@@ -101,6 +103,7 @@ describe("StateStore", () => {
 				makeInstance(),
 				makeInstance({ id: "instance-2", directory: "/tmp/project-two" }),
 			],
+			sessions: [],
 			jobs: [
 				makeJob(),
 				makeJob({ id: "job-2", instanceId: "instance-2" }),

--- a/packages/daemon/src/client.ts
+++ b/packages/daemon/src/client.ts
@@ -186,6 +186,18 @@ export class DaemonClient {
 		>;
 	}
 
+	listSessions(instanceId: string) {
+		return send(this.socketPath, "session.list", { instanceId }) as Promise<
+			ResultByMethod<"session.list">
+		>;
+	}
+
+	getSession(sessionId: string) {
+		return send(this.socketPath, "session.get", { sessionId }) as Promise<
+			ResultByMethod<"session.get">
+		>;
+	}
+
 	submitJob(params: ParamsByMethod<"job.submit">) {
 		return send(this.socketPath, "job.submit", params) as Promise<
 			ResultByMethod<"job.submit">

--- a/packages/daemon/src/protocol.ts
+++ b/packages/daemon/src/protocol.ts
@@ -90,6 +90,16 @@ const DaemonJob = z.strictObject({
 });
 export type DaemonJob = z.infer<typeof DaemonJob>;
 
+/** A conversation session belonging to an instance. */
+const DaemonSession = z.strictObject({
+	id: z.string().min(1),
+	instanceId: z.string().min(1),
+	title: z.string().min(1),
+	createdAt: IsoDateTime,
+	updatedAt: IsoDateTime,
+});
+export type DaemonSession = z.infer<typeof DaemonSession>;
+
 // ---------------------------------------------------------------------------
 // Request params — per-method input payloads
 // ---------------------------------------------------------------------------
@@ -136,6 +146,18 @@ const ProviderListParams = z.strictObject({
 });
 export type ProviderListParams = z.infer<typeof ProviderListParams>;
 
+// Session operations
+
+const SessionListParams = z.strictObject({
+	instanceId: z.string().min(1),
+});
+export type SessionListParams = z.infer<typeof SessionListParams>;
+
+const SessionGetParams = z.strictObject({
+	sessionId: z.string().min(1),
+});
+export type SessionGetParams = z.infer<typeof SessionGetParams>;
+
 // Job operations
 
 const JobSubmitParams = z.strictObject({
@@ -147,6 +169,7 @@ export type JobSubmitParams = z.infer<typeof JobSubmitParams>;
 
 const JobListParams = z.strictObject({
 	instanceId: z.string().min(1).optional(),
+	sessionId: z.string().min(1).optional(),
 	state: JobState.optional(),
 });
 export type JobListParams = z.infer<typeof JobListParams>;
@@ -209,6 +232,18 @@ const InstanceListResult = z.strictObject({
 	instances: z.array(ManagedInstance),
 });
 export type InstanceListResult = z.infer<typeof InstanceListResult>;
+
+// Session results
+
+const SessionListResult = z.strictObject({
+	sessions: z.array(DaemonSession),
+});
+export type SessionListResult = z.infer<typeof SessionListResult>;
+
+const SessionGetResult = z.strictObject({
+	session: DaemonSession,
+});
+export type SessionGetResult = z.infer<typeof SessionGetResult>;
 
 // Job results
 
@@ -337,6 +372,8 @@ const RequestMethod = z.enum([
 	"instance.stop",
 	"instance.remove",
 	"provider.list",
+	"session.list",
+	"session.get",
 	"job.submit",
 	"job.list",
 	"job.get",
@@ -405,6 +442,20 @@ const ProviderListRequest = z.strictObject({
 	params: ProviderListParams,
 });
 
+// Session requests
+
+const SessionListRequest = z.strictObject({
+	id: z.string().min(1),
+	method: z.literal("session.list"),
+	params: SessionListParams,
+});
+
+const SessionGetRequest = z.strictObject({
+	id: z.string().min(1),
+	method: z.literal("session.get"),
+	params: SessionGetParams,
+});
+
 // Job requests
 
 const JobSubmitRequest = z.strictObject({
@@ -448,6 +499,8 @@ export const RequestMessage = z.discriminatedUnion("method", [
 	InstanceStopRequest,
 	InstanceRemoveRequest,
 	ProviderListRequest,
+	SessionListRequest,
+	SessionGetRequest,
 	JobSubmitRequest,
 	JobListRequest,
 	JobGetRequest,
@@ -529,6 +582,22 @@ const ProviderListSuccess = z.strictObject({
 	result: ProviderListResult,
 });
 
+// Session successes
+
+const SessionListSuccess = z.strictObject({
+	id: z.string().min(1),
+	method: z.literal("session.list"),
+	ok: z.literal(true),
+	result: SessionListResult,
+});
+
+const SessionGetSuccess = z.strictObject({
+	id: z.string().min(1),
+	method: z.literal("session.get"),
+	ok: z.literal(true),
+	result: SessionGetResult,
+});
+
 // Job successes
 
 const JobSubmitSuccess = z.strictObject({
@@ -587,6 +656,8 @@ export const ResponseMessage = z.union([
 	InstanceStopSuccess,
 	InstanceRemoveSuccess,
 	ProviderListSuccess,
+	SessionListSuccess,
+	SessionGetSuccess,
 	JobSubmitSuccess,
 	JobListSuccess,
 	JobGetSuccess,
@@ -602,6 +673,7 @@ export type ResponseMessage = z.infer<typeof ResponseMessage>;
 
 export const DaemonState = z.strictObject({
 	instances: z.array(ManagedInstance),
+	sessions: z.array(DaemonSession),
 	jobs: z.array(DaemonJob),
 });
 export type DaemonState = z.infer<typeof DaemonState>;

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -14,6 +14,7 @@ import {
 import {
 	type CancelResult,
 	type DaemonJob,
+	type DaemonSession,
 	type DaemonState,
 	DaemonState as DaemonStateSchema,
 	type ErrorResponse,
@@ -35,6 +36,8 @@ import {
 	type ResponseError,
 	type ResponseMessage,
 	type ResultByMethod,
+	type SessionGetResult,
+	type SessionListResult,
 	type ShutdownResult,
 	type StreamAckResult,
 	type SubmitResult,
@@ -61,6 +64,22 @@ function extractText(parts: Part[]): string {
 		.trim();
 }
 
+const MAX_SESSION_TITLE_LENGTH = 80;
+
+function deriveSessionTitle(job: DaemonJob): string {
+	if (job.session.type === "new" && job.session.title) {
+		return job.session.title;
+	}
+	if (job.task.type === "prompt") {
+		const text = job.task.prompt.trim();
+		if (text.length > MAX_SESSION_TITLE_LENGTH) {
+			return `${text.slice(0, MAX_SESSION_TITLE_LENGTH - 3)}...`;
+		}
+		return text;
+	}
+	return "Untitled";
+}
+
 function normalizeErrorMessage(error: unknown): string {
 	if (error instanceof Error) {
 		return error.message;
@@ -85,6 +104,7 @@ export class Daemon {
 	private state: DaemonState = structuredClone(
 		DaemonStateSchema.parse({
 			instances: [],
+			sessions: [],
 			jobs: [],
 		}),
 	);
@@ -159,6 +179,10 @@ export class Daemon {
 					return this.success(raw, await this.handleInstanceRemove(raw));
 				case "provider.list":
 					return this.success(raw, await this.handleProviderList(raw));
+				case "session.list":
+					return this.success(raw, this.handleSessionList(raw));
+				case "session.get":
+					return this.success(raw, this.handleSessionGet(raw));
 				case "job.submit":
 					return this.success(raw, await this.handleJobSubmit(raw));
 				case "job.list":
@@ -311,6 +335,7 @@ export class Daemon {
 		await this.registry.stop(instance.id);
 		this.queues.delete(instance.id);
 		this.state = this.store.removeInstance(this.state, instance.id);
+		this.state = this.store.removeSessionsForInstance(this.state, instance.id);
 		await this.store.save(this.state);
 		return { instance };
 	}
@@ -322,6 +347,24 @@ export class Daemon {
 			request.params.directory,
 			request.params.refresh,
 		);
+	}
+
+	private handleSessionList(
+		request: RequestByMethod<"session.list">,
+	): SessionListResult {
+		return {
+			sessions: this.store.listSessions(this.state, {
+				instanceId: request.params.instanceId,
+			}),
+		};
+	}
+
+	private handleSessionGet(
+		request: RequestByMethod<"session.get">,
+	): SessionGetResult {
+		return {
+			session: this.store.assertSession(this.state, request.params.sessionId),
+		};
 	}
 
 	private async handleJobSubmit(
@@ -709,11 +752,22 @@ export class Daemon {
 			return job.sessionId;
 		}
 
+		const title = deriveSessionTitle(job);
 		const session = await client.session.create({
 			directory: instance.directory,
-			title: job.session.title,
+			title,
 		});
 		job.sessionId = session.id;
+
+		const now = new Date().toISOString();
+		const daemonSession: DaemonSession = {
+			id: session.id,
+			instanceId: instance.id,
+			title,
+			createdAt: now,
+			updatedAt: now,
+		};
+		this.state = this.store.upsertSession(this.state, daemonSession);
 		this.state = this.store.upsertJob(this.state, job);
 		await this.store.save(this.state);
 		return session.id;

--- a/packages/daemon/src/store.ts
+++ b/packages/daemon/src/store.ts
@@ -4,6 +4,7 @@ import type { z } from "zod";
 
 import {
 	type DaemonJob,
+	type DaemonSession,
 	type DaemonState,
 	DaemonState as DaemonStateSchema,
 	type ManagedInstance,
@@ -12,6 +13,7 @@ import {
 
 const EMPTY_STATE: DaemonState = {
 	instances: [],
+	sessions: [],
 	jobs: [],
 };
 
@@ -37,6 +39,16 @@ export class StateStore {
 		try {
 			const raw = await readFile(this.statePath, "utf8");
 			const parsed = JSON.parse(raw) as unknown;
+
+			// Migrate legacy state files that predate the sessions array.
+			if (
+				typeof parsed === "object" &&
+				parsed !== null &&
+				!("sessions" in parsed)
+			) {
+				(parsed as Record<string, unknown>).sessions = [];
+			}
+
 			const current = DaemonStateSchema.safeParse(parsed);
 			if (current.success) {
 				return current.data;
@@ -90,10 +102,17 @@ export class StateStore {
 
 	listJobs(
 		state: DaemonState,
-		filter: { instanceId?: string; state?: DaemonJob["state"] },
+		filter: {
+			instanceId?: string;
+			sessionId?: string;
+			state?: DaemonJob["state"];
+		},
 	): DaemonJob[] {
 		return state.jobs.filter((job: DaemonJob) => {
 			if (filter.instanceId && job.instanceId !== filter.instanceId) {
+				return false;
+			}
+			if (filter.sessionId && job.sessionId !== filter.sessionId) {
 				return false;
 			}
 			if (filter.state && job.state !== filter.state) {
@@ -155,6 +174,52 @@ export class StateStore {
 			...state,
 			instances: state.instances.filter(
 				(item: ManagedInstance) => item.id !== instanceId,
+			),
+		};
+	}
+
+	// Session operations
+
+	upsertSession(state: DaemonState, session: DaemonSession): DaemonState {
+		const sessions = state.sessions.filter(
+			(item: DaemonSession) => item.id !== session.id,
+		);
+		sessions.push(session);
+		sessions.sort((a: DaemonSession, b: DaemonSession) =>
+			a.createdAt < b.createdAt ? 1 : -1,
+		);
+		return { ...state, sessions };
+	}
+
+	getSession(state: DaemonState, sessionId: string): DaemonSession | undefined {
+		return state.sessions.find((item: DaemonSession) => item.id === sessionId);
+	}
+
+	listSessions(
+		state: DaemonState,
+		filter: { instanceId: string },
+	): DaemonSession[] {
+		return state.sessions.filter(
+			(item: DaemonSession) => item.instanceId === filter.instanceId,
+		);
+	}
+
+	assertSession(state: DaemonState, sessionId: string): DaemonSession {
+		const session = this.getSession(state, sessionId);
+		if (!session) {
+			throw new StoreError("not_found", `session ${sessionId} not found`);
+		}
+		return session;
+	}
+
+	removeSessionsForInstance(
+		state: DaemonState,
+		instanceId: string,
+	): DaemonState {
+		return {
+			...state,
+			sessions: state.sessions.filter(
+				(item: DaemonSession) => item.instanceId !== instanceId,
 			),
 		};
 	}


### PR DESCRIPTION
  ## Summary

  - Sessions are now first-class entities in the daemon's state model (`DaemonState.sessions`)
  - New RPC methods: `session.list`, `session.get`, and `sessionId` filter on `job.list`
  - Session creation is lazy — a `DaemonSession` is born as a side effect of the first job's execution, not before it. This mirrors chatbot UX where "new chat"
  is free and nothing persists until the user sends a message.
  - Session title is derived from the first prompt's text at creation time (truncated to 80 chars). The OpenCode SDK supports `session.update({ title })` for
  smarter titles later.
  - TUI dashboard shows a hierarchical view: instances → sessions → chat. Selecting a session hydrates that session's history via server-side filtering.
    - _the presentation of this is likely to be changed, a basic selection UI was created to demonstrate the effects of this refactor_
  - Instance removal cascades to its sessions.
  - Legacy `state.json` files without `sessions` are migrated on load.

  ## Test plan
  - [x] Session created when new-session job completes
  - [x] Long prompt titles truncated
  - [x] `session.get` returns specific session
  - [x] `job.list` filters by `sessionId`
  - [x] Instance removal cascades to sessions
  - [x] Legacy state migration
  - [x] Manual: dashboard shows sessions, selecting one loads history, "New Chat" starts fresh
